### PR TITLE
Automatic creation of container canvas

### DIFF
--- a/demos/simple-map.html
+++ b/demos/simple-map.html
@@ -7,14 +7,13 @@
 </head>
 <body> 
 <div id="mapContainer"> 
-<canvas id="mapCanvas"></canvas>
 </div>
 <script src="../dist/tile5.js"></script> 
 <script src="../dist/geo/osm.js"></script>
 <script>
 // initialise the map
 var map = T5.Map({
-        container: 'mapCanvas'
+        container: 'mapContainer'
     }),
     
     tiles = map.setLayer('tiles', new T5.ImageLayer('osm.cloudmade', {

--- a/src/js/graphics/view.js
+++ b/src/js/graphics/view.js
@@ -133,7 +133,7 @@ var View = function(params) {
     var layers = [],
         layerCount = 0,
         container = document.getElementById (params.container),
-        canvas = document.createElement ('canvas'),
+	canvas,
         mainContext = null,
         isIE = typeof window.attachEvent != 'undefined',
         offsetX = 0,
@@ -191,8 +191,11 @@ var View = function(params) {
         rectCenter = XYRect.center;
 
     //Add the canvas to the container
-    container.appendChild (canvas);
-
+    if(container.nodeName.toLowerCase() === 'canvas'){
+	canvas = container;
+    } else {
+	canvas = Images.newCanvas();
+    }
     /* event handlers */
     
     function handlePan(evt, x, y, inertia) {

--- a/src/js/graphics/view.js
+++ b/src/js/graphics/view.js
@@ -110,6 +110,7 @@ var View = function(params) {
     params = COG.extend({
         id: COG.objId('view'),
         container: "",
+	canvas: undefined,
         fastDraw: false,
         inertia: true,
         pannable: true,
@@ -131,7 +132,8 @@ var View = function(params) {
     // get the container context
     var layers = [],
         layerCount = 0,
-        canvas = document.getElementById(params.container),
+        container = document.getElementById (params.container),
+        canvas = document.createElement ('canvas'),
         mainContext = null,
         isIE = typeof window.attachEvent != 'undefined',
         offsetX = 0,
@@ -187,7 +189,10 @@ var View = function(params) {
     var vectorRect = XY.getRect,
         rectDiagonal = XYRect.diagonalSize,
         rectCenter = XYRect.center;
-        
+
+    //Add the canvas to the container
+    container.appendChild (canvas);
+
     /* event handlers */
     
     function handlePan(evt, x, y, inertia) {

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -297,21 +297,32 @@ var Images = (function() {
     } // load
     
     /**
-    ### newCanvas(width, height)
+    ### newCanvas()
     */
-    function newCanvas(width, height) {
-        var tmpCanvas = document.createElement('canvas');
+    function newCanvas() {
+	var args = arguments, //Little expensive, or so I hear
+	    parent = args[0] && args[0].nodeName ? args[0] : undefined,
+	    tmpCanvas = document.createElement('canvas');
+	
         COG.info('creating new canvas');
-
         // set the size of the canvas if specified
-        tmpCanvas.width = width ? width : 0;
-        tmpCanvas.height = height ? height : 0;
-        
+	if (parent) {
+            tmpCanvas.width = args[1] ? args[1] : 0;
+            tmpCanvas.height = args[2] ? args[2] : 0;
+	} else {
+            tmpCanvas.width = args[0] ? args[0] : 0;
+            tmpCanvas.height = args[1] ? args[1] : 0;
+	}
+	if (parent) {
+	    parent.appendChild(tmpCanvas);		
+	} else {
+	    document.body.appendChild(tmpCanvas);		
+	}
         // flash canvas initialization
         if (typeof FlashCanvas != 'undefined') {
-            document.body.appendChild(tmpCanvas);
+	    
             FlashCanvas.initElement(tmpCanvas);
-        } // if
+        }
 
         return tmpCanvas;
     } // newCanvas    


### PR DESCRIPTION
I thought this looked a little cooler.
This way user doesn't have to specify a canvas to use as the container, this could be alternatively created via some kind of shortcut for making canvas elements like Polymaps does.

```
var map = po.map()
    .container(document.body.appendChild(po.svg("svg")))
```

Secretly I'm seeing if I can send a pull request from a remote branch I'm tracking.
